### PR TITLE
CASMINST-5443 Use authentication for csm-python-modules

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ COPY requirements.txt /usr/src/app/
 # don't build cryptography Rust library
 ENV CRYPTOGRAPHY_DONT_BUILD_RUST 1
 RUN pip install --upgrade pip
-RUN pip3 install --no-cache-dir \
+RUN --mount=type=secret,id=netrc,target=/root/.netrc pip3 install --no-cache-dir \
                  --extra-index-url https://artifactory.algol60.net/artifactory/csm-python-modules/simple \
                  --trusted-host artifactory.algol60.net -r requirements.txt
 
@@ -56,7 +56,7 @@ COPY pylintrc test-requirements.txt .coveragerc /usr/src/app/
 # Allow the use of either pypi or DST here because this is not part of the
 # production delivered code, so it is less critical that everything be
 # strictly Cray provided.
-RUN pip3 install --no-cache-dir \
+RUN --mount=type=secret,id=netrc,target=/root/.netrc pip3 install --no-cache-dir \
                  --extra-index-url https://artifactory.algol60.net/artifactory/csm-python-modules/simple \
                  --trusted-host artifactory.algol60.net -r test-requirements.txt
 

--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -16,9 +16,9 @@ pipeline {
         IS_STABLE = getBuildIsStable()
         VERSION = getDockerBuildVersion(isStable: env.IS_STABLE)
         DOCKER_ARGS = getDockerBuildArgs(name: env.NAME, description: env.DESCRIPTION)
+        DOCKER_BUILDKIT = "1"
         BUILD_METADATA = getRpmRevision(isStable: env.IS_STABLE)
         CHART_VERSION = getChartVersion(version: env.VERSION)
-
     }
 
     stages {

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,9 @@ UNIT_TEST_NAME ?= cray-uas-mgr-unit-test
 # DOCKER
 NAME ?= cray-uas-mgr
 VERSION ?= $(shell cat .version)
+ifneq ($(wildcard ${HOME}/.netrc),)
+	DOCKER_ARGS ?= --secret id=netrc,src=${HOME}/.netrc
+endif 
 
 # Chart
 CHART_NAME ?= cray-uas-mgr

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ NAME ?= cray-uas-mgr
 VERSION ?= $(shell cat .version)
 ifneq ($(wildcard ${HOME}/.netrc),)
 	DOCKER_ARGS ?= --secret id=netrc,src=${HOME}/.netrc
-endif 
+endif
 
 # Chart
 CHART_NAME ?= cray-uas-mgr


### PR DESCRIPTION
## Summary and Scope

Optionally mount `~/.netrc` file as a secret to container created by `docker build` command, and use this secret to create `~/.netrc` file inside container. This file provides authentication for `csm-python-modules` repository for `pip` commands: https://pip.pypa.io/en/stable/topics/authentication/

File `~.netrc` is automatically mounted in jenkins environments.

## Issues and Related PRs

* Needed for [CASMINST-5443](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5443)

## Testing
### Tested on:

* Local system
* Jenkins

### Test description:

* Tested locally by temporarily changing PyPi repo reference to development instance which does require authentication
* Tested mounting of secret in Jenkins:
https://jenkins.algol60.net/job/Cray-HPE/job/uas-mgr/view/change-requests/job/PR-37/4/console

      00:00:57.106  docker build --pull --no-cache --secret id=netrc,src=/home/jenkins/.netrc --label "org.label-schema.name=cray-uas-mgr" --label "org.label-schema.description=Cray User Access Service Manager" --label "org.label-schema.build-date=2022-11-15T17:52:19Z" --label "org.label-schema.build-url=https://jenkins.algol60.net/job/Cray-HPE/job/uas-mgr/job/PR-37/" --label "org.label-schema.url=http://www.cray.com/" --label "org.label-schema.vcs-url=https://github.com/Cray-HPE/uas-mgr.git" --label "org.label-schema.vcs-ref=97fbec3c0700311b2fa495e788ab37b96803ce2d" --label "org.label-schema.vendor=Cray Inc" --label "org.label-schema.schema-version=1.0" --tag 'cray-uas-mgr-unit-test:1.22.0-20221115175219_97fbec3'  --target coverage .

## Risks and Mitigations
Low - change is backwards compatible.