### PR TITLE
CASMUSER-3160: Minor language linting of docs and API spec

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Language linting of API spec and other documentation (no content changes)
 
 ## [1.21.0] - 2022-05-10
 - Change to rolling version of Alpine 3
@@ -72,7 +73,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Switch to MIT License in preparation for releasing to GitHub
 
 ## [1.11.7] - 2021-02-14
-- CASMUAS-210 Helm Chart fixes to reapair macvlan route generation
+- CASMUAS-210 Helm Chart fixes to repair macvlan route generation
 
 ## [1.11.6] - 2021-02-11
 - CASMUAS-210 Helm Chart changes to support multiple macvlan routes
@@ -87,7 +88,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CASMUAS-196 Add uai_compute_network and sidecar configuration for UAS namespace
 
 ## [1.11.2] - 2020-11-10
-- CASMUAS-183 Add Administrative UAI Managememt APIs to UAS
+- CASMUAS-183 Add Administrative UAI Management APIs to UAS
 
 ## [1.11.1] - 2020-10-26
 - CASMUAS-182 Add support for configured UIA / Broker Classes in UAS
@@ -367,9 +368,9 @@ CASMUAS-113: Remove cray_uai_hosts tasks and role from playbook
 - Check for Ready & Labeled nodes
 - Add BUILD_NUMBER & git hash to Release
 - CASMUSER-1365: add UAI Diagnostics
-- STP-644: wording tweeks
+- STP-644: wording tweaks
 - STP-644: minor tweek
-- STP-644: Minor tag tweeks
+- STP-644: Minor tag tweaks
 - STP-644: Minor punctuation changes. Move ? to comments.
 - work in progress
 - swagger.yaml edited online with Bitbucket

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ image: uan-ci.us.cray.com:5000/cray-user-access-service:my_version
 ```
 
 5. Pull the cray-user-access-service image from the local docker
-registry to all kubernetes masters.
+registry to all Kubernetes masters.
 (uan-ci.us.cray.com:5000/cray-user-access-service:my_version): <br>
 **Note:**
 This download (pull) must be performed on all nodes in the Kubernetes
@@ -148,7 +148,7 @@ docker pull uan-ci.us.cray.com:5000/cray-user-access-service:my_version
 and start the Cray User Access Service:
 
 ```bash
-kubctl create -f cray-uas-deployment.yaml
+kubectl create -f cray-uas-deployment.yaml
 ```
 
 7. In a browser window, enter the following URL.  You should see the

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2020-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2020-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -77,7 +77,7 @@ info:
 
     ### /admin/config/images
 
-    This is where an administrator can list, create, get or delete UAI
+    This is where an administrator can list, create, get, or delete UAI
     image entries in the list of available container image names.
 
     ### /admin/config/volumes
@@ -125,7 +125,7 @@ info:
     the specified (or default) UAI image.  This happens if no default
     Class is configured (see Administrative Workflow).  If a
     default Class is configured, a POST on the /uas path creates a
-    UAI using the UAI Image, volume list and resource limits and
+    UAI using the UAI image, volume list, and resource limits and
     requests (if any) configured in the default Class.
 
     #### GET /uas
@@ -178,17 +178,17 @@ info:
     
     UAS Configuration covers the following:
 
-    * UAI Images
+    * UAI images
     * Volume Mounts
     * Resource Limits and Requests
     * UAI / Broker Classes
 
-    UAI Images are the container images used to create UAIs.  In the
+    UAI images are the container images used to create UAIs.  In the
     Single User Workflow (above) when no default Class is defined,
-    the user can request a specific UAI Image to be used.  In the
-    Administrative Workflow, a UAI Image can be associated with a UAI / Broker
+    the user can request a specific UAI image to be used.  In the
+    Administrative Workflow, a UAI image can be associated with a UAI / Broker
     Class and will then be used to create any UAI based on that class.
-    At most 1 UAI Image may be marked as the 'default' image, which
+    At most 1 UAI image may be marked as the 'default' image, which
     will cause it to be used when creating a UAI in the Single User
     Workflow if no image is specified in the POST on the /uas path and
     no default Class is configured.
@@ -215,7 +215,7 @@ info:
     instead of the UAI namespace default setting.
 
     UAI / Broker Classes allow administrators to define templates for creating
-    UAIs that define the UAI Image to be used, the list of Volume
+    UAIs that define the UAI image to be used, the list of Volume
     Mounts to be mounted in the UAI and the Resource Limits and
     Requests to be used when scheduling the UAI.  At most one UAI / Broker
     Class may be marked as 'default' in which case it will be used
@@ -355,7 +355,7 @@ paths:
     post:
       summary: "Create a UAI"
       description: |
-        Create a new UAI using the specified image.  It will be accessable
+        Create a new UAI using the specified image.  It will be accessible
         via ssh, and projected onto ports, if ports are specified.
       operationId: "create_uai"
       tags:
@@ -372,7 +372,7 @@ paths:
         in: "query"
         description: |
           Additional ports to project from the UAI besides ssh. Restricted
-          to ports 80, 443 and 8888.
+          to ports 80, 443, and 8888.
         required: false
         schema:
           type: "string"
@@ -414,7 +414,7 @@ paths:
       - "uas"
       parameters:
       - name: "uai_list"
-        description: "comma separated list of UAI names"
+        description: "comma-separated list of UAI names"
         in: "query"
         required: true
         style: form
@@ -622,7 +622,7 @@ paths:
           UAS system services and allow SSH connections from any
           user.  Alternatively, the username may be used to label a Broker
           UAI as needed by the site.  Whether or not the username is used
-          within a UAI is determined by the code running in the UAI Image.
+          within a UAI is determined by the code running in the UAI image.
           Brokers UAIs will generally not be used in the running Broker UAI
           but will be used in formatting the UAI name and similar activities.
         example: "swilliams"
@@ -707,7 +707,7 @@ paths:
         example: "swilliams"
       - name: "uai_list"
         description: |
-          Comma separated list of UAI names.  If this is supplied 'owner'
+          Comma-separated list of UAI names.  If this is supplied 'owner'
           and 'class-id' are ignored.
         in: "query"
         required: false
@@ -1116,7 +1116,7 @@ paths:
         description: |
           The name of the volume as it is applied to the UAI
           Kubernetes pod.  Must conform to Kubernetes volume
-          naming conventions (see Kuberneted documentation for
+          naming conventions (see Kubernetes documentation for
           details).
         required: false
         schema:
@@ -1526,7 +1526,7 @@ paths:
       - name: "opt_ports"
         in: "query"
         description: |
-          A comma separated list of port numbers on which software running in a
+          A comma-separated list of port numbers on which software running in a
           UAI created using this class may listen.  Unlike `ports` in the
           Single User UAI creation API, the port numbers here are not constrained
           by any configured range of available ports.  Any valid port number is
@@ -1573,7 +1573,7 @@ paths:
         example:  "af4e59ab-6275-47f9-8f4a-90911eba3f9c"
       - name: "volume_list"
         description: |
-          Optional comma separated list of volume-ids specifying the
+          Optional comma-separated list of volume-ids specifying the
           volume mounts to be included in the UAIs created using this
           Class.  Defaults to an empty list if not specified, in
           which case none of the available volume mounts will be mounted
@@ -1607,7 +1607,7 @@ paths:
             Optional JSON string containing a timeout specification
             for UAIs created using this class.  The value contains a
             JSON string specifying a map with three optional key /
-            value pairs, 'soft', 'hard' and 'warning'.  The 'soft'
+            value pairs, 'soft', 'hard', and 'warning'.  The 'soft'
             value specifies the number of seconds a UAI will run
             before it is eligible for termination due to being idle
             (i.e. no user is logged into it).  The 'hard' value
@@ -1833,7 +1833,7 @@ paths:
       - name: "opt_ports"
         in: "query"
         description: |
-          A comma separated list of port numbers on which software running in a
+          A comma-separated list of port numbers on which software running in a
           UAI created using this class may listen.  Unlike `ports` in the
           Single User UAI creation API, the port numbers here are not constrained
           by any configured range of available ports.  Any valid port number is
@@ -1877,7 +1877,7 @@ paths:
         example:  "af4e59ab-6275-47f9-8f4a-90911eba3f9c"
       - name: "volume_list"
         description: |
-          Comma separated list of volume-ids specifying the
+          Comma-separated list of volume-ids specifying the
           volume mounts to be included in the UAIs created using this
           UAI / Broker Class.
         in: "query"
@@ -1909,7 +1909,7 @@ paths:
             Optional JSON string containing a timeout specification
             for UAIs created using this class.  The value contains a
             JSON string specifying a map with three optional key /
-            value pairs, 'soft', 'hard' and 'warning'.  The 'soft'
+            value pairs, 'soft', 'hard', and 'warning'.  The 'soft'
             value specifies the number of seconds a UAI will run
             before it is eligible for termination due to being idle
             (i.e. no user is logged into it).  The 'hard' value

--- a/doc/test-plan/test-plan.md
+++ b/doc/test-plan/test-plan.md
@@ -10,13 +10,13 @@ The following is the test plan for the User Access Service (UAS).  The tests are
 Unit tests are standalone tests run automatically every time UAS is built and are intended to verify the internal logic of UAS.  Where the functionality under test requires access to an external service or sub-system that can be mocked, the expected behavior of the service or sub-system is mocked to permit testing of logic based on expected external behaviors.  Where functionality relies on external functionality that cannot be mocked, that functionality cannot be tested directly so the unit tests test around the external functionality as much as possible.  This results in incomplete coverage by unit tests.  Currently the minimum required test coverate for UAS is 75% of the combined unit test and functional code.
 |Summary|Description|Automated|Notes|
 |-------|-----------|---------|-----|
-|Create an Auth Object|Auth Objectes are created when a user operation is attempted, for example creating or listing UAIs in legacy mode|yes|test_uas_auth.py:test_UasAuth|
-|Get passwd entry from Auth Object|Auth objectes compose `/etc/passwd` style strings for use in creating legacy mode UAIs|yes|test_uas_auth.py:test_createPasswd|
+|Create an Auth Object|Auth Objects are created when a user operation is attempted, for example creating or listing UAIs in legacy mode|yes|test_uas_auth.py:test_UasAuth|
+|Get passwd entry from Auth Object|Auth objects compose `/etc/passwd` style strings for use in creating legacy mode UAIs|yes|test_uas_auth.py:test_createPasswd|
 |Detect Missing Attributes|An Auth object learns user Attributes from Keycloak, but receives proposed attributes in a JWT for legacy mode. Test the function that identifies missing attributes in the JWT attributes for error reporting|yes|test_uas_auth.py:test_missingAttributes|
 |Validate User Info|An Auth object validates arttributes proposed in a JWT against Keycloak attributes.  Test this function.|yes|test_uas_auth.py:test_validUserinfo|
 |Get user info with bad token|Test that trying to retrieve user information from an Auth object using an invalid token fails with an internal server error|yes|test_uas_auth.py:test_user_info|
 |Test Auth timeout exception logging|Verify that timeout exception handling while using Keycloak to create an Auth object produces the appropriate logging|yes|test_uas_auth.py:test_timeout|
-|Test Auth connection error logging|Verify that conection errors seen while using Keycloak to create Auth object produce appropriate logging|yes|test_uas_auth.py:test_connection_error|
+|Test Auth connection error logging|Verify that connection errors seen while using Keycloak to create Auth object produce appropriate logging|yes|test_uas_auth.py:test_connection_error|
 |Test Auth request handling|Verify that the various possible results for Keycloak requests are handled  correctly|yes|test_uas_auth.py:tests_requests|
 |500 responses in Auth|Test that 500 responses seen in Auth objects raise the correct werkzeug exception from UAS|yes|test_uas_auth.py:test_500|
 |404 responses in Auth|Test that 404 responses seen in Auth objects raise the correct werkzeug exception from UAS|yes|test_uas_auth.py:test_404|
@@ -43,7 +43,7 @@ Unit tests are standalone tests run automatically every time UAS is built and ar
 |Valid Volume Name|Test the volume name validator logic in the Config object|yes|test_uas_cfg.py:test_is_valid_volume_name|
 |Volume Descriptor Errors|Test construction and content of the volume descriptor error exception classes defined by the UAS configuration logic|yes|test_uas_cfg.py:test_vol_desc_errors|
 |Get UAI Namespace|Test getting the basic UAS configuration indicating the default UAI namespace|yes|test_uas_cfg.py:test_get_uai_namespace|
-|Data Model Expandale Get|Test logic in the UAS Data Model that is used to allow un-resolved references between configuration objects to be handled gracefully when expanding the contents of a configuration object|yes|test_uas_cfg.py:test_data_model_expandable_get|
+|Data Model Expandable Get|Test logic in the UAS Data Model that is used to allow un-resolved references between configuration objects to be handled gracefully when expanding the contents of a configuration object|yes|test_uas_cfg.py:test_data_model_expandable_get|
 |Delete UAI By Name|Test the UAS API entrypooint that deletes UAIs by name.  This test just verifies that the error condition created by trying to delete an empty list of UAIs reaches the code that will error out expecting a non-empty list.  Other unit tests test the underlying behavior for other cases.|yes|test_uas_controller.py:test_delete_uai_by_name|
 |Get UAS Images|Test the UAS API entrypoint that retrieves the list of UAI images.  This test just verifies that the API reaches the code to get an empty list of images.  Other unit tests verify behavior for other cases.|yes|test_uas_controller.py:test_get_uas_images|
 |Get UAI Image Registrations (admin)|Test the UAS Admin API for getting a list of UAI image Registrations and verify that it returns a list of images.|yes|test_uas_controller.py:test_get_uas_images_admin|
@@ -53,13 +53,13 @@ Unit tests are standalone tests run automatically every time UAS is built and ar
 |Delete UAI Image Registration (admin)|Test the UAS Admin API for deleting a UAI Image registration|yes|test_uas_controller.py:test_delete_uas_image_admin|
 |Get UAS Volume List (admin)|Test the UAS Admin API for listing UAS Volume Configuration|yes|test_uas_controller.py:test_get_uas_volumes_admin|
 |Create UAS Volume (admin)|Test the UAS Admin API for creating a UAS volume specification|yes|test_uas_controller.py:test_create_uas_volume_admin|
-|Get UAS Volume (admin)|Test the UAS Admin API for rettrieving a specific UAS volume specification|yes|test_uas_controller.py:test_get_uas_volume_admin|
+|Get UAS Volume (admin)|Test the UAS Admin API for retrieving a specific UAS volume specification|yes|test_uas_controller.py:test_get_uas_volume_admin|
 |Update UAS Volume|Test the UAS Admin API for updating a UAS volume specification|yes|test_uas_controller.py:test_update_uas_volume_admin|
 |Delete UAS Volume|Test the UAS Admin API for deleting a UAS volume specification|yes|test_uas_controller.py:test_delete_uas_volume_admin|
 |Get UAS Resource List|Test the UAS Admin API for listing UAS Resource specifications|yes|test_uas_controller.py:test_get_uas_resources_admin|
 |Get UAS Resource|Test the UAS Admin API for retrieving a specific UAS Resource specification|yes|test_uas_controller.py:test_get_uas_resource_admin NOTE: this includes creating a test resource which implicitly tests the Create UAS Resource API|
 |Update UAS Resource|Test the UAS Admin API for updating a UAS Resource specification|yes|test_uas_controller.py:test_update_uas_resource_admin|
-|Delete UAS Resource|Test the UAS Admin API for deleting UAS Reource specifications|yes|test_uas_controller.py:test_delete_uas_resource_admin|
+|Delete UAS Resource|Test the UAS Admin API for deleting UAS Resource specifications|yes|test_uas_controller.py:test_delete_uas_resource_admin|
 |Get UAI Class (admin)|Test the UAS Admin API for retrieving a UAI Class from the UAS config|yes|test_uas_controller.py:test_get_uas_class_admin|
 |Update UAI Class (admin)|Test the UAS Admin API for updating a UAI class in the UAS config|yes|test_uas_controller.py:test_update_uas_class_admin NOTE: this also creates test UAI Classes to test with through the API so tests that functionality implicitly|
 |Delete UAI Class|Test the UAS Admin API for deleting a UAI class from the UAS config|yes|test_uas_controller.py:test_delete_uas_class_admin|
@@ -72,7 +72,7 @@ Unit tests are standalone tests run automatically every time UAS is built and ar
 |Create Job Object|Test the UAS Internal operation of creating a Kubernetes Job structure for deploying a UAI|yes|test_uas_mgr.py:test_create_job_object|
 |Create Service Object|Test the UAS Internal operation of creating a Kubernetes Service structure for deploying a UAI|yes|test_uas_mgr.py:test_create_service_object|
 |Generate Connetion String|Test the UAS Internal operation of generating an SSH connection string with a '-p <port>' option for a UAI|yes|test_uas_mgr.py:test_gen_connection_string|
-|Generate Connection String No Port|Test the UAS Internal operation of generating an SSH conection string with no '-p <port>' option for a UAI|yes|test_uas_mgr.py:test_gen_connection_string_no_port|
+|Generate Connection String No Port|Test the UAS Internal operation of generating an SSH connection string with no '-p <port>' option for a UAI|yes|test_uas_mgr.py:test_gen_connection_string_no_port|
 |Image Lifecycle|Test the UAS Internal operations involved in a UAI Image registration lifecycle (create, get, update, list, delete)|yes|test_uas_mgr.py:test_image_lifecycle|
 |Host Path Volume Lifecycle|Test the UAS Internal operations involved in a 'host-path' type volume lifecycle (create, get, update, list, delete)|yes|test_uas_mgr.py:test_host_path_lifecycle|
 |Config Map Volume Lifecycle|Test the UAS Internal operations involved in a 'configmap' type volume lifecycle (create, get, update, list, delete)|yes|test_uas_mgr.py:test_config_map_lifecycle|
@@ -92,8 +92,8 @@ NOTE: the planned automated sanity tests are pretty comprehensive, but currently
 |-------|-----------|---------|-----|
 |Wait for UAS update|Wait for / verify that uas-update job is completed|no|This is a gating test for all other integration tests. It ensures that the UAS manager is running and that the up-to-date factory configuration has been merged with the UAS configuration.|
 |Verify required basic UAI image|Make sure that the basic (HPE supplied) UAS image to be used with the tests is in place|no|If the required image is not present, then update-uas failed in some way and we can't proceed with the testing|
-|Verify required basic UAI class is configured|Make sure that the basic (HPE supplied) UAI calss for sanity testing is in place|no|If the required class is not present, then update-uas failed in some way and we can't proceed with the testing|
-|Create a non-public End-User UAI|Use the administrative UAI creationg API endpoint to create a UAI using the basic sanity testing UAI class and image with a test user and test user keys|no|This demonstrates that end-user UAIs can be created|
+|Verify required basic UAI class is configured|Make sure that the basic (HPE supplied) UAI class for sanity testing is in place|no|If the required class is not present, then update-uas failed in some way and we can't proceed with the testing|
+|Create a non-public End-User UAI|Use the administrative UAI creating API endpoint to create a UAI using the basic sanity testing UAI class and image with a test user and test user keys|no|This demonstrates that end-user UAIs can be created|
 |Log into and validate non-public UAI|Use SSH to log into the end-user UAI created above and run ps(1) to show it works|no|This demostrates that the basic UAI image works for creating UAIs|
 |List UAIs|Use the admin UAI management API to list UAIs by owner and by class and verify that the UAI is found|no|This demonstrates that UAI listing works and that the by owner and by class selection filtering works|
 |Delete the end-user UAI|Delete the previously created UAI by owner and list uais to see that it goes away|no|This demonstrates UAI deletion works, the by owner and by class selection filtering has already been tested above|

--- a/doc/uas_overview.md
+++ b/doc/uas_overview.md
@@ -38,7 +38,7 @@
         4. [UAI Classes](#main-uasconfig-classes)
             1. [Listing UAI Classes](#main-uasconfig-classes-list)
             2. [Adding a UAI Class](#main-uasconfig-classes-add)
-            3. [Examinig a UAI Class](#main-uasconfig-classes-examine)
+            3. [Examining a UAI Class](#main-uasconfig-classes-examine)
             4. [Updating a UAI Class](#main-uasconfig-classes-update)
             5. [Deleting a UAI Class](#main-uasconfig-classes-delete)
     5. [UAI Management](#main-uaimanagement)
@@ -121,11 +121,11 @@ All of the above can be customized on a given set of UAIs by defining a UAI clas
 
 ### UAI Host Nodes <a name="main-concepts-hostnodes"></a>
 
-UAIs run on Kubernetes worker nodes.  There is a mechanism using Kubernetes labels to prevent UAIs from running on a specific worker node, however.  Any Kubernetes node that is not labeled to prevent UAIs from running on it is considered to be a UAI host node.  The administrator of a given site may control the set of UAI host nodes by labeling kubernetes worker nodes appropriately.
+UAIs run on Kubernetes worker nodes.  There is a mechanism using Kubernetes labels to prevent UAIs from running on a specific worker node, however.  Any Kubernetes node that is not labeled to prevent UAIs from running on it is considered to be a UAI host node.  The administrator of a given site may control the set of UAI host nodes by labeling Kubernetes worker nodes appropriately.
 
 ### UAI Network Attachments (macvlans) <a name="main-concepts-netattach"></a>
 
-UAIs need to be able to reach compute nodes across the node managment network (NMN).  When the compute node NMN is structured as multiple subnets, this requires routing form the UAIs to those subnets.  The default route in a UAI goes to the public network through the customer access network (CAN) so that will not work for reaching compute nodes.  To solve this problem, UAS installs Kubernetes network attachments within the Kubernetes `user` namespace, one of which is used by UAIs.  The type of network attachment used on Shasta hardware for this purpose is a `macvlan` network attachment, so this is often referred to on Shasta systems as "macvlans".  This network attachment integrates the UAI into the NMN on the UAI host node where the UAI is running and assigns the UAI an IP address on that network.  It also installs a set of routes in the UAI that are used to reach the compute node subnets on the NMN.
+UAIs need to be able to reach compute nodes across the node management network (NMN).  When the compute node NMN is structured as multiple subnets, this requires routing form the UAIs to those subnets.  The default route in a UAI goes to the public network through the customer access network (CAN) so that will not work for reaching compute nodes.  To solve this problem, UAS installs Kubernetes network attachments within the Kubernetes `user` namespace, one of which is used by UAIs.  The type of network attachment used on Shasta hardware for this purpose is a `macvlan` network attachment, so this is often referred to on Shasta systems as "macvlans".  This network attachment integrates the UAI into the NMN on the UAI host node where the UAI is running and assigns the UAI an IP address on that network.  It also installs a set of routes in the UAI that are used to reach the compute node subnets on the NMN.
 
 ## UAI Host Node Selection <a name="main-hostnodes"></a>
 
@@ -174,7 +174,7 @@ ncn-m001:~ # /opt/cray/csm/scripts/node_management/make_node_groups --help
 getopt: unrecognized option '--help'
 usage: make_node_groups [-m][-s][-u][w][-A][-R][-N]
 Where:
-  -m - creates a node group for managment master nodes
+  -m - creates a node group for management master nodes
 
   -s - creates a node group for management storage nodes
 
@@ -402,7 +402,7 @@ imagename = "registry.local/cray/custom-end-user-uai:latest"
 
 The output shown above shows three image registrations.  Each has an `imagename` indicating the image to be used to construct a UAI.
 
-    NOTE: simply registering a UAI image name does not make the image available. The image must also be created and stored in the container registry.  This is covered in [???where???].
+    NOTE: simply registering a UAI image name does not make the image available. The image must also be created and stored in the container registry.
 
 There is also a `default` flag.  If this flag is `true` the image will be used  whenever a UAI is created without specifying an image or UAI class as part of the creation.  Finally, there is an `image_id`, which identifies this image registration for later inspection, update, or deletion and for linking the image to a [UAI class](#main-uasconfig-classes).
 
@@ -505,8 +505,10 @@ ncn-m001-pit:~ # cray uas admin config volumes list
 Here is an example of the output from this command:
 
 ```
-ncn-m001-pit:~ # cray uas admin config volumes list
+ncn-m001-pit:~ # cray uas admin config volumes list --format toml
+```
 
+```toml
 [[results]]
 mount_path = "/lus"
 volume_id = "2b23a260-e064-4f3e-bee5-3da8e3664f29"
@@ -560,14 +562,15 @@ volumename = "timezone"
 [results.volume_description.host_path]
 path = "/etc/localtime"
 type = "FileOrCreate"
-
 ```
 
 This TOML formatted output can be challenging to read, so it may be more reasonable to obtain the information in YAML format:
 
 ```
 ncn-m001-pit:~ # cray uas admin config volumes list --format yaml
+```
 
+```yaml
 - mount_path: /lus
   volume_description:
     host_path:
@@ -620,7 +623,9 @@ or JSON format:
 
 ```
 ncn-m001-pit:~ # cray uas admin config volumes list --format json
+```
 
+```json
 [
   {
     "mount_path": "/lus",
@@ -739,6 +744,9 @@ The `--format` option can be used here to obtain formats other than TOML that ma
 
 ```
 ncn-m001-pit:~ # cray uas admin config volumes describe a0066f48-9867-4155-9268-d001a4430f5c --format json
+```
+
+```json
 {
   "mount_path": "/host_files/host_passwd",
   "volume_description": {
@@ -797,7 +805,10 @@ ncn-m001-pit:~ # cray uas admin config resources list
 for example:
 
 ```
-ncn-m001-pit:~ # cray uas admin config resources list
+ncn-m001-pit:~ # cray uas admin config resources list --format toml
+```
+
+```toml
 [[results]]
 comment = "my first example resource specification"
 limit = "{\"cpu\": \"300m\", \"memory\": \"250Mi\"}"
@@ -827,7 +838,7 @@ For example:
 ncn-m001-pit:~ # cray uas admin config resources create --request '{"cpu": "300m", "memory": "250Mi"}' --limit '{"cpu": "300m", "memory": "250Mi"}' --comment "my first example resource specification"
 ```
 
-This specifies a request / limit pair that requests and is constrained to 300 mili-CPUs (0.3 CPUs) and 250 MiB of memory (`250 * 1024 * 1024` bytes) for any UAI created with this limit specification.  By keeping the request and the limit the same, this ensures that a host node will not be oversubscribed by UAIs.  It is also legitimate to request less than the limit, though that risks over-subscription and is not recommended in most cases.  If the request is greater than the limit, UAIs created with the request specification will never be scheduled because they will not be able to provide the requested resources.
+This specifies a request / limit pair that requests and is constrained to 300 milliCPUs (0.3 CPUs) and 250 MiB of memory (`250 * 1024 * 1024` bytes) for any UAI created with this limit specification.  By keeping the request and the limit the same, this ensures that a host node will not be oversubscribed by UAIs.  It is also legitimate to request less than the limit, though that risks over-subscription and is not recommended in most cases.  If the request is greater than the limit, UAIs created with the request specification will never be scheduled because they will not be able to provide the requested resources.
 
 All of the configurable parts are optional when adding a resource specification.  If none are provided, an empty resource specification with only a `resource_id` will be created.
 
@@ -842,7 +853,10 @@ ncn-m001-pit:~ # cray uas admin config resources describe <resource-id>
 for example:
 
 ```
-ncn-m001-pit:~ # cray uas admin config resources describe 85645ff3-1ce0-4f49-9c23-05b8a2d31849
+ncn-m001-pit:~ # cray uas admin config resources describe 85645ff3-1ce0-4f49-9c23-05b8a2d31849 --format toml
+```
+
+```toml
 comment = "my first example resource specification"
 limit = "{\"cpu\": \"300m\", \"memory\": \"250Mi\"}"
 request = "{\"cpu\": \"300m\", \"memory\": \"250Mi\"}"
@@ -904,6 +918,9 @@ for example (using JSON format because it is a bit easier to read):
 
 ```
 ncn-m001-pit:~ # cray uas admin config classes list --format json
+```
+
+```json
 [
   {
     "class_id": "05496a5f-7e35-435d-a802-882c6425e5b2",
@@ -1079,7 +1096,7 @@ In the above output, there are three UAI classes:
 
 Taking apart the non-brokered end-user UAI class, the first part is:
 
-```
+```json
     "class_id": "bb28a35a-6cbc-4c30-84b0-6050314af76b",
     "comment": "Non-Brokered UAI User Class",
     "default": false,
@@ -1098,17 +1115,12 @@ The `class_id` field is the identifier used to refer to this class when examinin
 ncn-m001-pit:~ # cray uas admin uais create
 ```
 
-command.  The `comment` field is a free form string describing the UAI class.  The `default` field is a flag indicating whether this class is the default class.  The default class will be applied, overriding both the default UAI image and any specified image name, when the
-
-```
-ncn-m001-pit:~ # cray uas create
-```
-
+command.  The `comment` field is a free form string describing the UAI class.  The `default` field is a flag indicating whether this class is the default class.  The default class will be applied, overriding both the default UAI image and any specified image name, when the `cray uas create`
 command is used to create an end-user UAI for a user.  Setting a class to default gives the administrator fine grained control over the behavior of end-user UAIs that are created by authorized users in [legacy mode](#main-uaimanagement-legacymode).  The `namespace` field specifies the Kubernetes namespace in which this UAI will run.  It has the default setting of `user` here.  The `opt_ports` field is an empty list of TCP port numbers that will be opened on the external IP address of the UAI when it runs.  This controls whether services other than SSH can be run and reached publicly on the UAI.  The `priority_class_name` `"uai_priority"` is the default <a href="https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass">Kubernetes priority class</a> of UAIs.  If it were a different class, it would affect both Kubernetes default resource limit / request assignments and Kubernetes scheduling priority for the UAI.  The `public_ip` field is a flag that indicates whether the UAI should be given an external IP address LoadBalancer service so that clients outside the Kubernetes cluster can reach it, or only be given a Kubernetes Cluster-IP address.  For the most part, this controls whether the UAI is reachable by SSH from external clients, but it also controls whether the ports in `opt_ports` are reachable as well. The `resource_config` field is not set, but could be set to a resource specification to override namespace defaults on Kubernetes resource requests / limits.  The `uai_compute_network` flag indicates whether this UAI uses the macvlan mechanism to gain access to the Shasta compute node network.  This needs to be `true` to support workload management.  The `uai_creation_class` field is used by [broker UIAs](#main-uaimanagement-brokermode-brokerclasses) to tell the broker what kind of UAI to create when automatically generating a UAI.
 
 After all these individual items, we see the UAI Image to be used to create UIAs of this class:
 
-```
+```json
     "uai_image": {
       "default": true,
       "image_id": "ff86596e-9699-46e8-9d49-9cb20203df8c",
@@ -1118,7 +1130,7 @@ After all these individual items, we see the UAI Image to be used to create UIAs
 
 Finally we see a list of volumes that will show up in UAIs created using this class:
 
-```
+```json
     "volume_mounts": [
       {
         "mount_path": "/etc/localtime",
@@ -1190,7 +1202,7 @@ where `--image-id <image-id>` specifies the UAI image identifier of the UAI imag
 
 Only the `--image-id` option is required to create a UAI class.  In that case, a UAI class with the specified UAI Image and no volumes will be created.
 
-#### Examinig a UAI Class <a name="main-uasconfig-classes-examine"></a>
+#### Examining a UAI Class <a name="main-uasconfig-classes-examine"></a>
 
 To examine an existing UAI class, use a command of the following form
 
@@ -1202,6 +1214,9 @@ For example:
 
 ```
 ncn-m001-pit:~ # cray uas admin config classes describe --format yaml bb28a35a-6cbc-4c30-84b0-6050314af76b
+```
+
+```yaml
 class_id: bb28a35a-6cbc-4c30-84b0-6050314af76b
 comment: Non-Brokered UAI User Class
 default: false
@@ -1312,7 +1327,10 @@ where `[options]` include the following selection options:
 For example:
 
 ```
-ncn-m001-pit:~ # cray uas admin uais list --owner vers
+ncn-m001-pit:~ # cray uas admin uais list --owner vers --format toml
+```
+
+```toml
 [[results]]
 uai_age = "6h22m"
 uai_connect_string = "ssh vers@10.28.212.166"
@@ -1350,7 +1368,10 @@ cray uas admin uais describe <uai-name>
 for example:
 
 ```
-ncn-m001-pit:~ # cray uas admin uais describe uai-vers-715fa89d
+ncn-m001-pit:~ # cray uas admin uais describe uai-vers-715fa89d --format toml
+```
+
+```toml
 uai_age = "2d23h"
 uai_connect_string = "ssh vers@10.28.212.166"
 uai_host = "ncn-w001"
@@ -1362,7 +1383,6 @@ uai_status = "Running: Ready"
 username = "vers"
 
 [uai_portmap]
-
 ```
 
 #### Deleting UAIs <a name="main-uaimanagement-adminuai-delete"></a>
@@ -1382,7 +1402,10 @@ where options may be
 for example:
 
 ```
-ncn-m001-pit:~ # cray uas admin uais delete --uai-list 'uai-vers-715fa89d,uai-ctuser-0aed4970'
+ncn-m001-pit:~ # cray uas admin uais delete --uai-list 'uai-vers-715fa89d,uai-ctuser-0aed4970' --format toml
+```
+
+```toml
 results = [ "Successfully deleted uai-vers-715fa89d", "Successfully deleted uai-ctuser-0aed4970",]
 ```
 
@@ -1421,6 +1444,9 @@ For an example minimal system, here is an example set of volumes and an example 
 
 ```
 ncn-m001-pit:~ # cray uas admin config volumes list --format json
+```
+
+```json
 [
   {
     "mount_path": "/etc/localtime",
@@ -1445,8 +1471,13 @@ ncn-m001-pit:~ # cray uas admin config volumes list --format json
     "volumename": "lustre"
   }
 ]
+```
 
-ncn-m001-pit:~ # cray uas admin config images list
+```
+ncn-m001-pit:~ # cray uas admin config images list --format toml
+```
+
+```toml
 [[results]]
 default = false
 image_id = "c5dcb261-5271-49b3-9347-afe7f3e31941"
@@ -1461,8 +1492,13 @@ imagename = "dtr.dev.cray.com/cray/cray-uas-sles15:latest"
 default = true
 image_id = "ff86596e-9699-46e8-9d49-9cb20203df8c"
 imagename = "dtr.dev.cray.com/cray/cray-uai-sles15sp1:latest"
+```
 
-ncn-m001-pit:~ # cray uas admin config classes create --image-id ff86596e-9699-46e8-9d49-9cb20203df8c --volume-list '55a02475-5770-4a77-b621-f92c5082475c,9fff2d24-77d9-467f-869a-235ddcd37ad7' --uai-compute-network yes --public-ip yes --comment "my default legacy mode uai class" --default yes
+```
+ncn-m001-pit:~ # cray uas admin config classes create --image-id ff86596e-9699-46e8-9d49-9cb20203df8c --volume-list '55a02475-5770-4a77-b621-f92c5082475c,9fff2d24-77d9-467f-869a-235ddcd37ad7' --uai-compute-network yes --public-ip yes --comment "my default legacy mode uai class" --default yes --format toml
+```
+
+```toml
 class_id = "e2ea4845-5951-4c79-93d7-186ced8ce8ad"
 comment = "my default legacy mode uai class"
 default = true
@@ -1500,6 +1536,9 @@ Here is an example of a default UAI class configured for Slurm support if Slurm 
 
 ```
 ncn-m001-pit:~ # cray uas admin config volumes list --format json
+```
+
+```json
 [
   {
     "mount_path": "/etc/localtime",
@@ -1544,8 +1583,13 @@ ncn-m001-pit:~ # cray uas admin config volumes list --format json
     "volumename": "slurm-config"
   }
 ]
+```
 
-ncn-m001-pit:~ # cray uas admin config images list
+```
+ncn-m001-pit:~ # cray uas admin config images list --format toml
+```
+
+```toml
 [[results]]
 default = false
 image_id = "c5dcb261-5271-49b3-9347-afe7f3e31941"
@@ -1560,8 +1604,13 @@ imagename = "dtr.dev.cray.com/cray/cray-uas-sles15:latest"
 default = true
 image_id = "ff86596e-9699-46e8-9d49-9cb20203df8c"
 imagename = "dtr.dev.cray.com/cray/cray-uai-sles15sp1:latest"
+```
 
-ncn-m001-pit:~ # cray uas admin config classes create --image-id ff86596e-9699-46e8-9d49-9cb20203df8c --volume-list '55a02475-5770-4a77-b621-f92c5082475c,9fff2d24-77d9-467f-869a-235ddcd37ad7,7aeaf158-ad8d-4f0d-bae6-47f8fffbd1ad,ea97325c-2b1d-418a-b3b5-3f6488f4a9e2' --uai-compute-network yes --public-ip yes --comment "my default legacy mode uai class" --default yes
+```
+ncn-m001-pit:~ # cray uas admin config classes create --image-id ff86596e-9699-46e8-9d49-9cb20203df8c --volume-list '55a02475-5770-4a77-b621-f92c5082475c,9fff2d24-77d9-467f-869a-235ddcd37ad7,7aeaf158-ad8d-4f0d-bae6-47f8fffbd1ad,ea97325c-2b1d-418a-b3b5-3f6488f4a9e2' --uai-compute-network yes --public-ip yes --comment "my default legacy mode uai class" --default yes --format toml
+```
+
+```toml
 class_id = "c0a6dfbc-f74c-4f2c-8c8e-e278ff0e14c6"
 comment = "my default legacy mode uai class"
 default = true
@@ -1635,10 +1684,18 @@ Username: vers
 Password: 
 Success!
 
-vers:~ $ cray uas list
-results = []
+vers:~ $ cray uas list --format toml
+```
 
-vers:~ $ cray uas create --publickey ~/.ssh/id_rsa.pub 
+```toml
+results = []
+```
+
+```
+vers:~ $ cray uas create --publickey ~/.ssh/id_rsa.pub --format toml
+```
+
+```toml
 uai_age = "0m"
 uai_connect_string = "ssh vers@10.103.13.157"
 uai_host = "ncn-w001"
@@ -1650,8 +1707,13 @@ uai_status = "Waiting"
 username = "vers"
 
 [uai_portmap]
+```
 
-vers:~ $ cray uas list
+```
+vers:~ $ cray uas list --format toml
+```
+
+```toml
 [[results]]
 uai_age = "0m"
 uai_connect_string = "ssh vers@10.103.13.157"
@@ -1662,8 +1724,9 @@ uai_msg = ""
 uai_name = "uai-vers-8ee103bf"
 uai_status = "Running: Ready"
 username = "vers"
+```
 
-
+```
 vers:~ $ ssh vers@10.103.13.157
 The authenticity of host '10.103.13.157 (10.103.13.157)' can't be established.
 ECDSA key fingerprint is SHA256:XQukF3V1q0Hh/aTiFmijhLMcaOzwAL+HjbM66YR4mAg.
@@ -1679,7 +1742,10 @@ nid000003
 vers@uai-vers-8ee103bf-95b5d774-88ssd:~ > exit
 logout
 Connection to 10.103.13.157 closed.
-vers:~ $ cray uas delete --uai-list uai-vers-8ee103bf
+vers:~ $ cray uas delete --uai-list uai-vers-8ee103bf --format toml
+```
+
+```toml
 results = [ "Successfully deleted uai-vers-8ee103bf",]
 ```
 
@@ -1695,7 +1761,10 @@ user:~ $ cray uas images list
 
 For example:
 ```
-vers:~ $ cray uas images list
+vers:~ $ cray uas images list --format toml
+```
+
+```toml
 default_image = "dtr.dev.cray.com/cray/cray-uai-sles15sp1:latest"
 image_list = [ "dtr.dev.cray.com/cray/cray-uai-broker:latest", "dtr.dev.cray.com/cray/cray-uas-sles15:latest", "dtr.dev.cray.com/cray/cray-uai-sles15sp1:latest",]
 ```
@@ -1711,11 +1780,19 @@ user:~ $ cray uas create --publickey <path> --imagename <image-name>
 where `<image-name>` is the name shown above in the list of UAI images.  For example:
 
 ```
-vers:~ $ cray uas images list
+vers:~ $ cray uas images list --format toml
+```
+
+```toml
 default_image = "dtr.dev.cray.com/cray/cray-uai-sles15sp1:latest"
 image_list = [ "dtr.dev.cray.com/cray/cray-uai-broker:latest", "dtr.dev.cray.com/cray/cray-uas-sles15:latest", "dtr.dev.cray.com/cray/cray-uai-sles15sp1:latest",]
+```
 
-vers:~ $ cray uas create --publickey ~/.ssh/id_rsa.pub --imagename dtr.dev.cray.com/cray/cray-uas-sles15:latest
+```
+vers:~ $ cray uas create --publickey ~/.ssh/id_rsa.pub --imagename dtr.dev.cray.com/cray/cray-uas-sles15:latest --format toml
+```
+
+```toml
 uai_connect_string = "ssh vers@10.103.13.160"
 uai_host = "ncn-w001"
 uai_img = "dtr.dev.cray.com/cray/cray-uas-sles15:latest"
@@ -1830,7 +1907,10 @@ ncn-m001-pit:~ # kubectl create secret generic -n uas broker-sssd-conf --from-fi
 Next make a volume for the secret in the UAS configuration:
 
 ```
-ncn-m001-pit:~ # cray uas admin config volumes create --mount-path /etc/sssd --volume-description '{"secret": {"secret_name": "broker-sssd-conf", "default_mode": 384}}' --volumename broker-sssd-config 
+ncn-m001-pit:~ # cray uas admin config volumes create --mount-path /etc/sssd --volume-description '{"secret": {"secret_name": "broker-sssd-conf", "default_mode": 384}}' --volumename broker-sssd-config --format toml
+```
+
+```toml
 mount_path = "/etc/sssd"
 volume_id = "4dc6691e-e7d9-4af3-acde-fc6d308dd7b4"
 volumename = "broker-sssd-config"
@@ -1848,7 +1928,10 @@ Two important things to notice here are:
 The last part that is needed is a UAI class for the broker UAI with the updated configuration in the volume list.  For this we need the image-id of the broker UAI image, the volume-ids of the volumes to be added to the broker class and the class-id of the end-user UAI class managed by the broker:
 
 ```
-ncn-m001-pit:~ # cray uas admin config images list
+ncn-m001-pit:~ # cray uas admin config images list --format toml
+```
+
+```toml
 [[results]]
 default = false
 image_id = "c5dcb261-5271-49b3-9347-afe7f3e31941"
@@ -1863,7 +1946,9 @@ imagename = "dtr.dev.cray.com/cray/cray-uas-sles15:latest"
 default = true
 image_id = "ff86596e-9699-46e8-9d49-9cb20203df8c"
 imagename = "dtr.dev.cray.com/cray/cray-uai-sles15sp1:latest"
+```
 
+```
 ncn-m001-pit:~ # cray uas admin config volumes list | grep -e volume_id -e volumename
 volume_id = "4dc6691e-e7d9-4af3-acde-fc6d308dd7b4"
 volumename = "broker-sssd-config"
@@ -1886,7 +1971,10 @@ comment = "Non-Brokered UAI User Class"
 Using that information create the broker UAI class
 
 ```
-ncn-m001-pit:~ # cray uas admin config classes create --image-id c5dcb261-5271-49b3-9347-afe7f3e31941 --volume-list '4dc6691e-e7d9-4af3-acde-fc6d308dd7b4,55a02475-5770-4a77-b621-f92c5082475c,9fff2d24-77d9-467f-869a-235ddcd37ad7' --uai-compute-network no --public-ip yes --comment "UAI broker class" --uai-creation-class a623a04a-8ff0-425e-94cc-4409bdd49d9c --namespace uas
+ncn-m001-pit:~ # cray uas admin config classes create --image-id c5dcb261-5271-49b3-9347-afe7f3e31941 --volume-list '4dc6691e-e7d9-4af3-acde-fc6d308dd7b4,55a02475-5770-4a77-b621-f92c5082475c,9fff2d24-77d9-467f-869a-235ddcd37ad7' --uai-compute-network no --public-ip yes --comment "UAI broker class" --uai-creation-class a623a04a-8ff0-425e-94cc-4409bdd49d9c --namespace uas --format toml
+```
+
+```toml
 class_id = "74970cdc-9f94-4d51-8f20-96326212b468"
 comment = "UAI broker class"
 default = false
@@ -1938,7 +2026,10 @@ ncn-m001-pit:~ # cray uas admin uais create --class-id <class-id> [--owner <name
 To make the broker obvious in the list of UAIs, giving it an owner name of `broker` is handy.  The owner name on a broker is used for naming and listing, but nothing else, so this is a convenient convention.  Here is an example using the class created above:
 
 ```
-ncn-m001-pit:~ # cray uas admin uais create --class-id 74970cdc-9f94-4d51-8f20-96326212b468 --owner broker
+ncn-m001-pit:~ # cray uas admin uais create --class-id 74970cdc-9f94-4d51-8f20-96326212b468 --owner broker --format toml
+```
+
+```toml
 uai_connect_string = "ssh broker@10.103.13.162"
 uai_img = "dtr.dev.cray.com/cray/cray-uai-broker:latest"
 uai_ip = "10.103.13.162"
@@ -2833,9 +2924,9 @@ The procedure is to find the name of the UAI in question, use that with `kubectl
 
 If problems occur while making or working with a custom end-user UAI image some basic troubleshooting questions to ask are:
 
-* Does SESSION_NAME match an actual entry in "cray bos v1 sessiontemplate list"?
-* Is SESSION_ID set to an appropriate uuid format? Did the awk command not parse the uuid correctly?
-* Did the file /etc/security/limits.d/99-slingshot-network.conf get removed from the tarball correctly?
-* Does the ENTRYPOINT /usr/bin/uai-ssh.sh exist?
+* Does SESSION_NAME match an actual entry in `cray bos v1 sessiontemplate list`?
+* Is SESSION_ID set to an appropriate UUID format? Did the `awk` command not parse the UUID correctly?
+* Did the file `/etc/security/limits.d/99-slingshot-network.conf` get removed from the tarball correctly?
+* Does the ENTRYPOINT `/usr/bin/uai-ssh.sh` exist?
 * Did the container image get pushed and registered with UAS?
 * Did the creation process run from a real worker or master node as opposed to a LiveCD node?


### PR DESCRIPTION
## Summary and Scope

Linting of minor language issues (spelling, punctuation, capitalization) in API spec file and a few documentation files. No functional impact.

## Issues and Related PRs

- Resolves [CASMUSER-3160](https://jira-pro.its.hpecorp.net:8443/browse/CASMUSER-3160)
- After this PR merges, [this PR in the craycli repo](https://github.com/Cray-HPE/craycli/pull/76) will propagate the API spec language corrections into the CLI

## Testing

None -- all changes were to contents of text fields.

I did run the updated API spec through an openapi linter, to make sure I did not accidentally introduce any new issues.

## Risks and Mitigations

Very very low risk.

## Pull Request Checklist

- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
