### PR TITLE
CASMCMS-8713: Pin PyYAML to 6.0.1 to prevent build issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ sshpubkeys >= 3.1.0
 etcd3_model >= 1.0.0
 flask == 2.2.5
 markupsafe==2.1.1
+PyYAML == 6.0.1

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -9,6 +9,7 @@ pluggy>=0.9.0
 py>=1.10.0
 pytest>=4.4.1
 pytest-cov>=2.6.1
+PyYAML==6.0.1
 randomize==0.14
 scandir==1.10.0
 six>=1.12.0


### PR DESCRIPTION
## Summary and Scope

With the release of Cython 3, any Alpine images trying to install PyYAML hit failures due to [this upstream issue](https://github.com/yaml/pyyaml/issues/601). See [CASMCMS-8713](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8713) for full details. The TL;DR summary is that moving to PyYAML 6.0.1 resolves the problem. 

In the case of this repo, the PyYAML version isn't pinned, but it is getting pulled in through other dependencies. This PR pins the version to 6.0.1.

This PR allows builds in this repo to once again work, while making no functional changes to the things being built.

## Issues and Related PRs

* [PyYAML upstream issue](https://github.com/yaml/pyyaml/issues/601)
* [PR that created PyYAML 6.0.1 to fix the problem](https://github.com/yaml/pyyaml/pull/702)
* [CASMCMS-8713](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8713) - The Jira ticket I'm using to fix the affected CSM repos

## Risks and Mitigations

Very low risk. And without this, the repo builds will fail.

## Pull Request Checklist

- [X] License file intact
- [X] Target branch correct
